### PR TITLE
Fix FileService.DownloadFile, update example

### DIFF
--- a/box.go
+++ b/box.go
@@ -112,7 +112,7 @@ func (c *Client) Do(req *http.Request, respStr interface{}) (*http.Response, err
 }
 
 // Do "makes" the request, and if there are no errors and resp is not nil,
-// it attempts to unmarshal the  (json) response body into resp.
+// it returns the resp without reading or closing the resp.Body.
 func (c *Client) DoAndGetReader(req *http.Request) (*http.Response, io.ReadCloser, error) {
 	resp, err := c.Client.Do(req)
 	if err != nil {

--- a/examples/files/downloadfile/main.go
+++ b/examples/files/downloadfile/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/ttacon/box"
 	"github.com/ttacon/pretty"
@@ -54,8 +55,13 @@ func main() {
 	resp, err := c.FileService().DownloadFile(*fileId)
 	pretty.Print(resp)
 	fmt.Println("err: ", err)
-	// TODO(ttacon): actually download the file here for the example
-	// to be more complete
+
+	// Read the content into bs
+	var bs []byte
+	defer resp.Body.Close()
+	bs, err = ioutil.ReadAll(resp.Body)
+	fmt.Println("ioutil.ReadAll err: ", err)
+	fmt.Println("read %d bytes", len(bs))
 
 	// Print out the new tokens for next time
 	fmt.Printf("%#v\n", tok)

--- a/files.go
+++ b/files.go
@@ -183,7 +183,8 @@ func (c *FileService) DownloadFile(fileId string) (*http.Response, error) {
 		return nil, err
 	}
 
-	return c.Do(req, nil)
+	resp, _, err := c.DoAndGetReader(req)
+	return resp, err
 }
 
 // Documentation: https://developers.box.com/docs/#files-view-versions-of-a-file


### PR DESCRIPTION
When DownloadFile originally called client.Do(req, nil), the resp.Body was
closed and consumers of the http.Response given by
FileService.DownloadFile were unable to actually read the contents of the file.

This patch uses the client.DoAndGetReader method to return a response
with an unclosed reader. It also updates the example to count the bytes
in the file contents.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ttacon/box/4)

<!-- Reviewable:end -->
